### PR TITLE
Add details on export table size

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -128,7 +128,6 @@ fn sections(buf: &[u8]) -> Result<Vec<(String, u64, Section)>, Error> {
 
                 // Include the export table size. We'll put this in `Data` I guess.
                 if let Some(table) = hdr.data_directories.get_export_table() {
-                    let table = hdr.data_directories.get_export_table().unwrap();
                     vec.push(("export_table".to_string(), table.size as u64, Section::Data));
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,6 +125,12 @@ fn sections(buf: &[u8]) -> Result<Vec<(String, u64, Section)>, Error> {
                 } else {
                     vec.push((".bss".to_string(), bss, Section::Bss));
                 }
+
+                // Include the export table size. We'll put this in `Data` I guess.
+                if hdr.data_directories.get_export_table().is_some() {
+                    let table = hdr.data_directories.get_export_table().unwrap();
+                    vec.push(("export_table".to_string(), table.size as u64, Section::Data));
+                }
             }
 
             vec

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,7 +127,7 @@ fn sections(buf: &[u8]) -> Result<Vec<(String, u64, Section)>, Error> {
                 }
 
                 // Include the export table size. We'll put this in `Data` I guess.
-                if hdr.data_directories.get_export_table().is_some() {
+                if let Some(table) = hdr.data_directories.get_export_table() {
                     let table = hdr.data_directories.get_export_table().unwrap();
                     vec.push(("export_table".to_string(), table.size as u64, Section::Data));
                 }


### PR DESCRIPTION
dmajor needs this for [bug 1523352](https://bugzilla.mozilla.org/show_bug.cgi?id=1523352). On Windows we can use the value in the optional header, on OSX `goblin` provides an enumeration over exports but not actual size info so we just provide the count.

I just shoehorned this into the `Data` section, in theory we could add another section type or a separate command but that's probably more work than I care to put into this.